### PR TITLE
Front page UI changes

### DIFF
--- a/src/app/data.service.ts
+++ b/src/app/data.service.ts
@@ -34,6 +34,18 @@ export class DataService {
     return this.http.get(`${apiPath}/datasets/visible`);
   }
 
+  public getAgp(apiPath: string): Observable<boolean> {
+    return this.http
+      .get(`${apiPath}/autism_gene_tool/single-view/configuration`).pipe(
+        map(res => {
+          if (Object.keys(res).length === 0) {
+            return false;
+          }
+          return true;
+        })
+      );
+  }
+
   public logout(): Observable<object> {
     const csrfToken = this.cookieService.get('csrftoken');
     const headers = { 'X-CSRFToken': csrfToken };

--- a/src/app/instance/instance.component.css
+++ b/src/app/instance/instance.component.css
@@ -24,11 +24,16 @@ table, #documentation-link {
   font-size: 24px;
   vertical-align: middle;
   padding: 10px 8px 10px 8px;
+  background-color: #eeeeee;
 }
 
 .top-header {
-  background-color: #eeeeee;
-  height: 35px;
+  font-size: 20px;
+  font-weight: 500;
+}
+
+#agp-link {
+  float: right;
 }
 
 .fa-lock {

--- a/src/app/instance/instance.component.css
+++ b/src/app/instance/instance.component.css
@@ -28,7 +28,7 @@ table, #documentation-link {
 }
 
 .top-header {
-  font-size: 20px;
+  font-size: 22px;
   font-weight: 500;
 }
 

--- a/src/app/instance/instance.component.html
+++ b/src/app/instance/instance.component.html
@@ -1,6 +1,7 @@
 <table *ngIf="content && loadingFinished">
   <thead>
     <tr>
+        <div><a [attr.href]="frontendPath" target="_blank">{{ frontendPathToShow }}</a> instance</div>
       <th class="big-title top-header" colspan="2">
         <span><a [attr.href]="frontendPath" target="_blank">{{ frontendPath }}</a> instance</span>
       </th>

--- a/src/app/instance/instance.component.html
+++ b/src/app/instance/instance.component.html
@@ -1,21 +1,22 @@
-
+<div *ngIf="content && loadingFinished">
   <div class="top-header" colspan="2">
     <span><a [attr.href]="frontendPath" target="_blank">{{ frontendPathToShow }}</a> instance</span>
     <span *ngIf="hasAgp" id="agp-link"><a [attr.href]="agpPath" target="_blank">Autism gene profiles</a></span>
   </div>
 
-<table *ngIf="content && loadingFinished">
-  <thead>
-    <tr>
-      <th scope="col" class="big-title">Dataset</th>
-      <th scope="col" class="big-title" style="font-size: 16px; font-weight: bold">Access</th>
-    </tr>
-  </thead>
-  <tbody>
-    <ng-container *ngTemplateOutlet="datasets; context: { entries: content['data'], nesting: 0, instance: instance}">
-    </ng-container>
-  </tbody>
-</table>
+  <table>
+    <thead>
+      <tr>
+        <th scope="col" class="big-title">Dataset</th>
+        <th scope="col" class="big-title" style="font-size: 16px; font-weight: bold">Access</th>
+      </tr>
+    </thead>
+    <tbody>
+      <ng-container *ngTemplateOutlet="datasets; context: { entries: content['data'], nesting: 0, instance: instance}">
+      </ng-container>
+    </tbody>
+  </table>
+</div>
 
 <ng-template #datasets let-entries="entries" let-nesting="nesting" let-instance="instance">
   <ng-container *ngFor="let entry of entries">

--- a/src/app/instance/instance.component.html
+++ b/src/app/instance/instance.component.html
@@ -22,7 +22,7 @@
       <tr>
         <td [ngStyle]="{'padding-left': (nesting * 60 || 8) + 'px'}">
           <h4 [style.margin-bottom]="entry.description ? '8px' : '0'">
-            <a [attr.href]="constructLink(entry.dataset)" target="_blank">{{ entry.name }}</a>
+            <a [attr.href]="constructLink(entry.dataset)" [style.font-size]="nesting ? 24 - 2 * nesting + 'px' : '24px'" target="_blank">{{ entry.name }}</a>
           </h4>
           <markdown [data]="entry.description"></markdown>
         </td>

--- a/src/app/instance/instance.component.html
+++ b/src/app/instance/instance.component.html
@@ -1,13 +1,13 @@
+
+  <div class="top-header" colspan="2">
+    <span><a [attr.href]="frontendPath" target="_blank">{{ frontendPathToShow }}</a> instance</span>
+    <span *ngIf="hasAgp" id="agp-link"><a [attr.href]="agpPath" target="_blank">Autism gene profiles</a></span>
+  </div>
+
 <table *ngIf="content && loadingFinished">
   <thead>
     <tr>
-        <div><a [attr.href]="frontendPath" target="_blank">{{ frontendPathToShow }}</a> instance</div>
-      <th class="big-title top-header" colspan="2">
-        <span><a [attr.href]="frontendPath" target="_blank">{{ frontendPath }}</a> instance</span>
-      </th>
-    </tr>
-    <tr>
-      <th scope="col" class="big-title" style="font-size: 16px; font-weight: bold">Dataset</th>
+      <th scope="col" class="big-title">Dataset</th>
       <th scope="col" class="big-title" style="font-size: 16px; font-weight: bold">Access</th>
     </tr>
   </thead>

--- a/src/app/instance/instance.component.ts
+++ b/src/app/instance/instance.component.ts
@@ -14,6 +14,8 @@ export class InstanceComponent implements OnChanges {
   public instancePath: string = null;
   public frontendPath: string = null;
   public frontendPathToShow: string = null;
+  public hasAgp: boolean;
+  public agpPath: string = null;
   public content: object = null;
 
   public allStudies = new Set();
@@ -27,6 +29,9 @@ export class InstanceComponent implements OnChanges {
     this.instancePath = environment.instances[this.instance].apiPath;
     this.frontendPath = environment.instances[this.instance].frontendPath;
     this.frontendPathToShow = this.frontendPath.replace(/((http|https):\/\/)|(\/\/)/g,'');
+
+    this.dataService.getAgp(this.instancePath).subscribe(res => this.hasAgp = res);
+    this.agpPath = environment.instances[this.instance].frontendPath + '/autism-gene-profiles';
   
     combineLatest({
       datasets: this.dataService.getDatasetHierarchy(this.instancePath),

--- a/src/app/instance/instance.component.ts
+++ b/src/app/instance/instance.component.ts
@@ -13,6 +13,7 @@ export class InstanceComponent implements OnChanges {
   @Input() public instance: string;
   public instancePath: string = null;
   public frontendPath: string = null;
+  public frontendPathToShow: string = null;
   public content: object = null;
 
   public allStudies = new Set();
@@ -25,6 +26,7 @@ export class InstanceComponent implements OnChanges {
   ngOnChanges(): void {
     this.instancePath = environment.instances[this.instance].apiPath;
     this.frontendPath = environment.instances[this.instance].frontendPath;
+    this.frontendPathToShow = this.frontendPath.replace(/((http|https):\/\/)|(\/\/)/g,'');
   
     combineLatest({
       datasets: this.dataService.getDatasetHierarchy(this.instancePath),

--- a/src/app/instance/instance.component.ts
+++ b/src/app/instance/instance.component.ts
@@ -25,7 +25,7 @@ export class InstanceComponent implements OnChanges {
   ngOnChanges(): void {
     this.instancePath = environment.instances[this.instance].apiPath;
     this.frontendPath = environment.instances[this.instance].frontendPath;
-
+  
     combineLatest({
       datasets: this.dataService.getDatasetHierarchy(this.instancePath),
       visibleDatasets: this.dataService.getVisibleDatasets(this.instancePath)
@@ -42,7 +42,9 @@ export class InstanceComponent implements OnChanges {
     entry['children']?.forEach((d: object) => this.attachDatasetDescription(d));
     this.dataService.getDatasetDescription(this.instancePath, entry['dataset']).pipe(take(1)).subscribe(res => {
       if (res['description']) {
-        entry['description'] = res['description'].substring(res['description'].indexOf('\n\n') + 1);
+        let regex = new RegExp(/^\n((?:\n|.)*?)\n$/, 'm');
+        let match = regex.exec(res['description']);
+        entry['description'] = match ? match[0] : res['description'].substring(res['description'].indexOf('\n'))
       }
 
       this.studiesLoaded++;


### PR DESCRIPTION
Front page ui need some improvements:
- exclude `//`, `http://` and `https://` from instance link (example: `//dory.seqpipe.org:8000/hg38//` -> `dory.seqpipe.org:8000/hg38` and `http://localhost123:4200/` -> `localhost123:4200`)
- study descriptions to have only the first paragraph and to remove duplicate names (some studies have their names as a header in their description)
- font-size of studies names need to be different depending on the hierarchy
- add link to Autism gene profiles if there is agp configuration
- change table ui - exclude instance link and agp link from the table and change table header style
