### PR TITLE
change description element to be span

### DIFF
--- a/src/app/instance/instance.component.css
+++ b/src/app/instance/instance.component.css
@@ -6,6 +6,10 @@ table, th, td {
   border: 1px solid rgb(218, 218, 218) !important;
 }
 
+h4 {
+  display: inline;
+  margin-right: 3px;
+}
 
 table {
   margin-bottom: 44px;

--- a/src/app/instance/instance.component.html
+++ b/src/app/instance/instance.component.html
@@ -26,7 +26,7 @@
           <h4 [style.margin-bottom]="entry.description ? '8px' : '0'">
             <a [attr.href]="constructLink(entry.dataset)" [style.font-size]="nesting ? 24 - 2 * nesting + 'px' : '24px'" target="_blank">{{ entry.name }}</a>
           </h4>
-          <markdown [data]="entry.description"></markdown>
+          <span> {{entry.description}}</span>
         </td>
         <td class="access-td">
           <i


### PR DESCRIPTION
Make description element to be `span` and give `display: inline` property to `h4` element which holds the header in order to put the header and the description in one line .